### PR TITLE
Fix crash in ClarifaiOutput.m

### DIFF
--- a/Clarifai/Classes/ClarifaiOutput.m
+++ b/Clarifai/Classes/ClarifaiOutput.m
@@ -14,6 +14,10 @@
     self = [super init];
     if (self) {
         
+        if ([dict[@"data"] isKindOfClass: [NSNull class]]) {
+            return self;
+        }
+
         // add link to input, to the output. (contains media like images).
         ClarifaiInput *input = [[ClarifaiInput alloc] initWithDictionary:dict[@"input"]];
         self.input = input;


### PR DESCRIPTION
When trying to predict on a GIF, the "input" and "data" keys in the returned dictionary are null, which causes a crash ("(unrecognized selector") when trying to access them as a dictionary. 
This fix changes that.