### PR TITLE
Re-enable image selection button in Example after recognize completes

### DIFF
--- a/Example/Clarifai/RecognitionViewController.m
+++ b/Example/Clarifai/RecognitionViewController.m
@@ -70,6 +70,11 @@
                     self.textView.text = [NSString stringWithFormat:@"Tags:\n%@", [tags componentsJoinedByString:@", "]];
                 });
             }
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                self.button.enabled = YES;
+            });
+
         }];
     }];
 }


### PR DESCRIPTION
Title says it all. 

I realize it's just an example, but it was driving me nuts that I had to repeatedly force close the example app when demoing the clarifiai API to co-workers. 

Side question, I saw that there once existed a swift version of the example app. Looks like it was deleted in #10. What happened there?  Are you taking Swift pull requests? 